### PR TITLE
Fix "KeyNotFoundException" error

### DIFF
--- a/Csharp-Lox/Lox/Interpreter/Resolver.cs
+++ b/Csharp-Lox/Lox/Interpreter/Resolver.cs
@@ -345,7 +345,7 @@ namespace Lox
 
         public object Visit(Expr.Variable _variable)
         {
-            if (_scopes.Count != 0 && !_scopes.Peek()[_variable.name.lexeme])
+            if (_scopes.Count != 0 && _scopes.Peek().TryGetValue(_variable.name.lexeme, out bool value) && value == false)
             {
                 Lox.Error(_variable.name, "Cannot read local variable in its own initializer.");
             }


### PR DESCRIPTION
Fix the issue raised in this [issue](https://github.com/dhitchin/Lox-interpreter/issues/1).

I just use the "TryGetValue" method to be sure that the value exists before checking is value.

In Java, the "get" method return null when the value does not exist but in C# trying accessing the value throw an error.

P.S : This is my first pull request, sorry in advance if I have done something wrong.