### PR TITLE
Fix resolver scope distance and environment assignment causing "'this' not present" runtime error

### DIFF
--- a/Csharp-Lox/Lox/Interpreter/Resolver.cs
+++ b/Csharp-Lox/Lox/Interpreter/Resolver.cs
@@ -43,11 +43,12 @@ namespace Lox
 
         private void ResolveLocal(Expr expr, Token name)
         {
-            for (int i = _scopes.Count - 1; i >=0; i--)
+            var scopesArray = _scopes.ToArray();
+            for (int i = 0; i < scopesArray.Length; i++)
             {
-                if (_scopes.ToArray()[i].ContainsKey(name.lexeme))
+                if (scopesArray[i].ContainsKey(name.lexeme))
                 {
-                    _interpreter.Resolve(expr, _scopes.Count - 1 - i);
+                    _interpreter.Resolve(expr, i);
                     return;
                 }
             }


### PR DESCRIPTION
Fixes a runtime KeyNotFoundException when calling instance methods (example: this not found inside method).

Reproduction (minimal)
class Cake {
  Init() {
    this.test = 6;
  }
}
var cake = Cake();
cake.Init(); // previously caused KeyNotFoundException: "'this' was not present in the dictionary."
